### PR TITLE
Add type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,11 @@
   "version": "1.3.0",
   "description": "A stripped-back spring animation library for high-frequency animations",
   "type": "module",
+  "main": "src/index.js",
+  "types": "./types.d.ts",
   "exports": {
     ".": {
-      "default": "./src/index.js",
+      "import": "./src/index.js",
       "types": "./types.d.ts"
     }
   },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   "files": [
     "LICENSE",
     "README.md",
-    "src/index.js"
+    "src/index.js",
+    "types.d.ts"
   ],
   "author": "Ryan King",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,13 @@
   "name": "simple-spring",
   "version": "1.3.0",
   "description": "A stripped-back spring animation library for high-frequency animations",
-  "main": "src/index.js",
+  "type": "module",
+  "exports": {
+    ".": {
+      "default": "./src/index.js",
+      "types": "./types.d.ts"
+    }
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,33 +1,31 @@
-declare module 'simple-spring' {
-  export interface SpringOptions {
-    value?: number | number[]
-    target?: number | number[]
-    tension?: number
-    friction?: number
-    mass?: number
-    precision?: number
-    fps?: number
-    onStart?: ((value: number | number[], spring: Spring) => void) | null
-    onFrame?: ((value: number | number[], spring: Spring) => void) | null
-    onRest?: ((value: number | number[], spring: Spring) => void) | null
-    onComplete?: ((value: number | number[], spring: Spring) => void) | null
-  }
+export interface SpringOptions {
+  value?: number | number[]
+  target?: number | number[]
+  tension?: number
+  friction?: number
+  mass?: number
+  precision?: number
+  fps?: number
+  onStart?: ((value: number | number[], spring: Spring) => void) | null
+  onFrame?: ((value: number | number[], spring: Spring) => void) | null
+  onRest?: ((value: number | number[], spring: Spring) => void) | null
+  onComplete?: ((value: number | number[], spring: Spring) => void) | null
+}
 
-  export class Spring {
-    constructor(options?: SpringOptions)
-    set value(val: number | number[])
-    get value(): number | number[]
-    getValue(): number | number[]
-    set target(val: number | number[])
-    get target(): number | number[]
-    setTarget(val: number | number[]): this
-    start(): this
-    pause(): this
-    stop(): this
-    complete(): this
-    tick(t?: number): this
-    animateFrame(): void
-    get restingAtTarget(): boolean
-    get restingAtStart(): boolean
-  }
+export class Spring {
+  constructor(options?: SpringOptions)
+  set value(val: number | number[])
+  get value(): number | number[]
+  getValue(): number | number[]
+  set target(val: number | number[])
+  get target(): number | number[]
+  setTarget(val: number | number[]): this
+  start(): this
+  pause(): this
+  stop(): this
+  complete(): this
+  tick(t?: number): this
+  animateFrame(): void
+  get restingAtTarget(): boolean
+  get restingAtStart(): boolean
 }

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,33 @@
+declare module 'simple-spring' {
+  export interface SpringOptions {
+    value?: number | number[]
+    target?: number | number[]
+    tension?: number
+    friction?: number
+    mass?: number
+    precision?: number
+    fps?: number
+    onStart?: ((value: number | number[], spring: Spring) => void) | null
+    onFrame?: ((value: number | number[], spring: Spring) => void) | null
+    onRest?: ((value: number | number[], spring: Spring) => void) | null
+    onComplete?: ((value: number | number[], spring: Spring) => void) | null
+  }
+
+  export class Spring {
+    constructor(options?: SpringOptions)
+    set value(val: number | number[])
+    get value(): number | number[]
+    getValue(): number | number[]
+    set target(val: number | number[])
+    get target(): number | number[]
+    setTarget(val: number | number[]): this
+    start(): this
+    pause(): this
+    stop(): this
+    complete(): this
+    tick(t?: number): this
+    animateFrame(): void
+    get restingAtTarget(): boolean
+    get restingAtStart(): boolean
+  }
+}


### PR DESCRIPTION
This adds type definitions for the `Spring` class, and adds `type: "module"` to the `package.json` to make the package ESM-ready. These changes should make `simple-spring` easier to use. 

I just stumbled onto this library while searching for a simple spring physics function by the way, and really love the scope. It does exactly what I need!